### PR TITLE
Switch to version for from debian

### DIFF
--- a/exim/Dockerfile
+++ b/exim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie
+FROM debian:13
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Needed for dependabot to understand that it needs to update from 13 to 14 when 14 will be available.