### PR TITLE
fix: mail name sed command

### DIFF
--- a/exim/docker-entrypoint.d/00-update-config
+++ b/exim/docker-entrypoint.d/00-update-config
@@ -6,7 +6,7 @@ echo "root: $POSTMASTER" >> /etc/aliases
 
 /usr/bin/newaliases
 
-sed -i s/{helo_data}/${MAILNAME}/ /etc/exim4/update-exim4.conf.conf
+sed -i s/{helo_data}/${MAILNAME}/ /etc/exim4/exim4.conf.localmacros
 
 if [ -n "$RELAY_HOST" ]; then
     SMART_HOST=${RELAY_HOST}::${RELAY_PORT:-25}


### PR DESCRIPTION
Before the mail name was not used due to a sed on the incorrect file name.
This led to issues like:
```
│   294 connected                                                                                                                                                                            │
│   294   SMTP<< 220 smtp.inrae.fr Microsoft ESMTP MAIL Service ready at Wed, 5 Nov 2025 10:56:20 +0100                                                                                      │
│   294   SMTP>> EHLO {helo_data}                                                                                                                                                            │
│   294   SMTP<< 501 5.5.4 Invalid domain name                                                                                                                                               │
│   294   SMTP>> HELO {helo_data}                                                                                                                                                            │
│   294   SMTP<< 501 5.5.4 Invalid domain name                                                                                                                                               │
│   294   SMTP>> QUIT                                                                                                                                                                        │
│   294   SMTP(close)>>
```